### PR TITLE
Add Jest configuration with initial unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(react-native|@react-native|react-clone-referenced-element|@react-navigation)/)'
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prebuild": "expo prebuild",
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "format": "eslint \"**/*.{js,jsx,ts,tsx}\" --fix",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/metro-config": "^0.20.14",
@@ -71,7 +72,12 @@
     "@react-native-community/cli": "^18.0.0",
     "@types/react": "~19.0.10",
     "tailwindcss": "^3.4.0",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "jest": "^29.7.0",
+    "jest-expo": "^49.0.1",
+    "@testing-library/react-native": "^12.1.5",
+    "react-test-renderer": "19.0.0",
+    "@testing-library/jest-native": "^5.4.2"
   },
   "eslintConfig": {
     "extends": "universe/native",

--- a/src/api/api.test.js
+++ b/src/api/api.test.js
@@ -1,0 +1,22 @@
+import { setLanguage, setTheme } from './api';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(),
+}));
+
+describe('api utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('setLanguage stores language in AsyncStorage', async () => {
+    await setLanguage('es');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('language', 'es');
+  });
+
+  test('setTheme stores theme in AsyncStorage', async () => {
+    await setTheme('dark');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('theme', 'dark');
+  });
+});

--- a/src/components/FilterButton.test.jsx
+++ b/src/components/FilterButton.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import FilterButton from './FilterButton';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: () => 'Filter' }),
+}));
+
+jest.mock('react-native-vector-icons/FontAwesome5', () => 'Icon');
+
+describe('FilterButton', () => {
+  test('calls onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <FilterButton onPress={onPress} className="" textClassName="" iconColor="black" />
+    );
+    fireEvent.press(getByText('Filter'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/src/providers/ThemeProvider.test.jsx
+++ b/src/providers/ThemeProvider.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-native';
+import { ThemeProvider, useAppTheme } from './ThemeProvider';
+
+function wrapper({ children }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe('useAppTheme', () => {
+  test('throws error when used outside provider', () => {
+    const { result } = renderHook(() => {
+      try {
+        useAppTheme();
+      } catch (e) {
+        return e;
+      }
+    });
+    expect(result.current).toBeInstanceOf(Error);
+  });
+
+  test('returns theme context inside provider', () => {
+    const { result } = renderHook(() => useAppTheme(), { wrapper });
+    expect(result.current).toHaveProperty('theme');
+    expect(result.current).toHaveProperty('colorScheme');
+    expect(result.current).toHaveProperty('setTheme');
+  });
+
+  test('setTheme updates theme', () => {
+    const { result } = renderHook(() => useAppTheme(), { wrapper });
+    act(() => {
+      result.current.setTheme('dark');
+    });
+    expect(result.current.theme).toBe('dark');
+  });
+});

--- a/src/services/notifications.test.js
+++ b/src/services/notifications.test.js
@@ -1,0 +1,36 @@
+import { sendPushTokenToBackend, handleNotification, handleNotificationResponse } from './notifications';
+import api from '~/api/api';
+
+jest.mock('~/api/api', () => ({
+  post: jest.fn(() => Promise.resolve({ data: 'ok' })),
+}));
+
+describe('notifications service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('sendPushTokenToBackend posts token data', async () => {
+    const token = { data: '123' };
+    const result = await sendPushTokenToBackend(token);
+    expect(api.post).toHaveBeenCalledWith('/notifications/register-token', {
+      token: '123',
+      deviceType: expect.any(String),
+    });
+    expect(result).toBe('ok');
+  });
+
+  test('handleNotification logs output', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    handleNotification('note');
+    expect(logSpy).toHaveBeenCalledWith('Notificación recibida:', 'note');
+    logSpy.mockRestore();
+  });
+
+  test('handleNotificationResponse logs output', () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    handleNotificationResponse('resp');
+    expect(logSpy).toHaveBeenCalledWith('Respuesta a la notificación:', 'resp');
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a test script and testing dependencies
- configure jest for React Native
- add tests for API utilities
- add tests for ThemeProvider hook
- add tests for FilterButton component
- add tests for notification helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4157c28832ba22fcd57f1fdfbb6